### PR TITLE
Update Debugger.cs

### DIFF
--- a/Ultrapowa Clash Server/Core/Debugger.cs
+++ b/Ultrapowa Clash Server/Core/Debugger.cs
@@ -19,7 +19,7 @@ namespace UCS.Core
 
         static Debugger()
         {
-            m_vTextWriter = TextWriter.Synchronized(File.AppendText("logs/debug_" + DateTime.Now.ToString("yyyyMMdd") + ".log"));
+            m_vTextWriter = TextWriter.Synchronized(File.AppendText("logs/debug.log"));
             m_vLogLevel = 1;
         }
 


### PR DESCRIPTION
makes it very difficult to read the file from an online admin panel which I am creating due to the date being the date the server was started, this will allow the file to be easily read as one whole stream. 

we can easily set a cron job on our servers to delete the log every x amount of time or even using c# with System.IO.File.WriteAllText(@"logs/debug.log",string.Empty);